### PR TITLE
Add Screenshot caption to metainfo.xml

### DIFF
--- a/com.jetpackduba.Gitnuro.metainfo.xml
+++ b/com.jetpackduba.Gitnuro.metainfo.xml
@@ -15,8 +15,9 @@
 	<launchable type="desktop-id">com.jetpackduba.Gitnuro.desktop</launchable>
 	<content_rating type="oars-1.1" />
 	<screenshots>
-		<screenshot>
+		<screenshot type="default">
 			<image type="source">https://github.com/JetpackDuba/Gitnuro/raw/main/res/img/cover.png</image>
+			<caption>The Gitnuro main window</caption>
 		</screenshot>
 	</screenshots>
 	<releases>


### PR DESCRIPTION
Fixes appstream validation error "appstream-screenshot-missing-caption: One or more screenshots are missing captions in the Metainfo file"