### PR TITLE
Update runtime to 24.08

### DIFF
--- a/com.jetpackduba.Gitnuro.yml
+++ b/com.jetpackduba.Gitnuro.yml
@@ -1,6 +1,6 @@
 app-id: com.jetpackduba.Gitnuro
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17


### PR DESCRIPTION
The runtime should be updated quickly
- It's unsupported and insecure
- GNOME Software will flag the application as unsupported, hiding it from users